### PR TITLE
wrap setTimeout code in function to prevent CSP errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const dispatch = event => {
     composed,
     detail: { originalEvent: event }
   })
-  setTimeout(event.target.dispatchEvent(debouncedEvent))
+  setTimeout(() => { event.target.dispatchEvent(debouncedEvent) })
 }
 
 export const initializeEvent = (name, options = {}) => {


### PR DESCRIPTION
The old syntax is not recommended for the same reasons that make using eval() a security risk.