### PR TITLE
Fix CSP Violation: Use Named Function Instead of eval in Dispatch Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debounced",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Debounced versions of standard high frequency DOM events",
   "main": "src/index.js",
   "repository": "https://github.com/hopsoft/debounced",

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,12 @@ const dispatch = event => {
     composed,
     detail: { originalEvent: event }
   })
-  setTimeout(() => { event.target.dispatchEvent(debouncedEvent) })
+
+  const dispatchDebouncedEvent = () => {
+    event.target.dispatchEvent(debouncedEvent);
+  };
+
+  setTimeout(dispatchDebouncedEvent)
 }
 
 export const initializeEvent = (name, options = {}) => {


### PR DESCRIPTION
Throws a CSP violation for codebases with content security policies that do not allow unsafe-inline policies. The CSP violation occurs due to the use of setTimeout with an expression that could be interpreted as inline JavaScript, which is restricted by the CSP directive.

This fixes the violation by modifying the dispatch method to use a named function as a callback inside setTimeout instead of evaluating.

- Refactored the dispatch method to create a named function (dispatchDebouncedEvent) as a callback for setTimeout.
- Moved the event.target.dispatchEvent(debouncedEvent) code into the named function.
- Updated the setTimeout call to use the named function as the callback.