### PR TITLE
Scope debouncing to the event target

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,12 @@ import events from './events'
 
 let prefix = 'debounced'
 const initializedEvents = {}
+/**
+ * Mapping of target id to their associated timeout ids
+ * @type {Object.<string, number>}
+ */
+const timeoutIds = {}
+let idGenerator = 0
 
 export const debounce = (fn, options = {}) => {
   const { wait, leading, trailing } = { leading: false, trailing: true, ...options }
@@ -23,6 +29,42 @@ export const debounce = (fn, options = {}) => {
   }
 }
 
+/**
+ * Get the id of the element or generate one if it doesn't exist
+ * @param element {HTMLElement}
+ * @param attributeKey {string}
+ * @returns {string}
+ */
+const getOrGenerateId = (element, attributeKey) => {
+  let id = element.getAttribute(attributeKey)
+  if (!id) {
+    id = idGenerator++
+    element.setAttribute(attributeKey, id.toString())
+  }
+  return id
+}
+
+export const debounceEvent = (fn, options = {}) => {
+  const { wait, leading, trailing } = { leading: false, trailing: true, ...options }
+  let leadingOccurrence = false
+  let occurrenceCount = 0
+  return event => {
+    occurrenceCount += 1
+    leadingOccurrence = leading && occurrenceCount == 1
+    if (leadingOccurrence) fn(event)
+    const target = event.target
+    const key = `${prefix}-id`
+    const targetId = target ? getOrGenerateId(target, key) : 'no-target'
+    const timeoutId = timeoutIds[targetId]
+    clearTimeout(timeoutId)
+    timeoutIds[targetId] = setTimeout(() => {
+      delete timeoutIds[targetId]
+      if (trailing && !leadingOccurrence) fn(event)
+    }, wait)
+  }
+}
+
+
 const dispatch = event => {
   const { bubbles, cancelable, composed } = event
   const debouncedEvent = new CustomEvent(`${prefix}:${event.type}`, {
@@ -31,7 +73,6 @@ const dispatch = event => {
     composed,
     detail: { originalEvent: event }
   })
-
   const dispatchDebouncedEvent = () => {
     event.target.dispatchEvent(debouncedEvent);
   };
@@ -42,7 +83,7 @@ const dispatch = event => {
 export const initializeEvent = (name, options = {}) => {
   if (initializedEvents[name]) return
   initializedEvents[name] = options || {}
-  const debouncedDispatch = debounce(dispatch, options)
+  const debouncedDispatch = debounceEvent(dispatch, options)
   document.addEventListener(name, event => debouncedDispatch(event))
 }
 


### PR DESCRIPTION
If 2 elements of the same type occurs on the same time, one may be ignored as both the event will be dispatch through the same channel. This makes sure that they can't share the same timeoutId if they are pointing to different targets.

Fix #15 

I decided to duplicate `debounce` to `debounceEvent` to keep the backward compatibility.
